### PR TITLE
Update fix gpg agent py3 for use on Amazon AWS

### DIFF
--- a/file_roots/setup/debian/debian8/init.sls
+++ b/file_roots/setup/debian/debian8/init.sls
@@ -5,12 +5,15 @@
 {% set prefs_text = 'Package: *
         Pin: origin ""
         Pin-Priority: 1001
+
         Package: *
-        Pin: release a=' ~ os_codename ~ '-backports
+        Pin: release n=' ~ os_codename ~ '-backports
         Pin-Priority: 750
+
         Package: *
-        Pin: release a=' ~ os_codename ~ '
+        Pin: release n=' ~ os_codename ~ '
         Pin-Priority: 720
+
         Package: *
         Pin: release a=oldstable
         Pin-Priority: 700
@@ -26,15 +29,15 @@ build_additional_pkgs:
   pkg.installed:
     - pkgs:
       - python-support
-{% if build_cfg.build_arch == 'amd64' %}
+{%- if build_cfg.build_arch == 'amd64' %}
       - python3-lockfile
-{% endif %}
+{%- endif %}
       - dh-systemd
       - dh-python
       - python-setuptools-git
 
 
-{% if build_cfg.build_py3 %}
+{%- if build_cfg.build_py3 %}
 build_additional_py3_pkgs:
   pkg.installed:
     - pkgs:
@@ -49,7 +52,7 @@ build_additional_py3_pkgs:
       - python3-all-dev
       - python3-debian
       - apt-utils
-{% endif %}
+{%- endif %}
 
 
 build_pbldhooks_rm_G05:
@@ -72,32 +75,6 @@ build_prefs_rm:
     - name: /etc/apt/preferences
 
 
-build_pbldhooks_file_G05:
-  file.append:
-    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/G05apt-preferences
-    - makedirs: True
-    - text: |
-        #!/bin/sh
-        set -e
-        cat > "/etc/apt/preferences" << @EOF
-        {{prefs_text}}
-        @EOF
-
-
-build_pbldhooks_file_D04:
-  file.append:
-    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/D04update_local_repo
-    - makedirs: True
-    - text: |
-        #!/bin/sh
-        # path to local repo
-        LOCAL_REPO="{{build_cfg.build_dest_dir}}"
-        # Generate a Packages file
-        ( cd ${LOCAL_REPO} ; /usr/bin/apt-ftparchive packages . > "${LOCAL_REPO}/Packages" )
-        # Update to include any new packagers in the local repo
-        apt-get --allow-unauthenticated update
-
-
 build_pbldhooks_perms:
   file.directory:
     - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/
@@ -111,10 +88,49 @@ build_pbldhooks_perms:
         - mode
 
 
+build_pbldhooks_file_G05:
+  file.managed:
+    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/G05apt-preferences
+    - makedirs: True
+    - dir_mode: 0755
+    - mode: 0775
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - contents: |
+        #!/bin/sh
+        set -e
+        cat > "/etc/apt/preferences" << @EOF
+        {{prefs_text}}
+        @EOF
+
+
+build_pbldhooks_file_D04:
+  file.managed:
+    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/D04update_local_repo
+    - makedirs: True
+    - dir_mode: 0755
+    - mode: 0775
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - contents: |
+        #!/bin/sh
+        # path to local repo
+        LOCAL_REPO="{{build_cfg.build_dest_dir}}"
+        # Generate a Packages file
+        ( cd ${LOCAL_REPO} ; /usr/bin/apt-ftparchive packages . > "${LOCAL_REPO}/Packages" )
+        # Update to include any new packagers in the local repo
+        apt-get --allow-unauthenticated update
+
+
 build_pbldrc:
-  file.append:
+  file.managed:
     - name: {{build_cfg.build_homedir}}/.pbuilderrc
-    - text: |
+    - makedirs: True
+    - dir_mode: 0755
+    - mode: 0775
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - contents: |
         DIST="{{os_codename}}"
         LOCAL_REPO="{{build_cfg.build_dest_dir}}"
         ## export CCACHE_DIR='/var/cache/pbuilder/ccache'
@@ -140,15 +156,15 @@ build_pbldrc:
           APTCACHE="/var/cache/pbuilder/${DIST}/aptcache"
         fi
         HOOKDIR="${HOME}/.pbuilder-hooks"
-{% if build_cfg.build_arch == 'armhf' %}
+{%- if build_cfg.build_arch == 'armhf' %}
         DEBOOTSTRAPOPTS=( 
             '--variant=buildd' 
             '--keyring' "/etc/apt/trusted.gpg"
         )
         OTHERMIRROR="deb [trusted=yes] file:${LOCAL_REPO} ./ | deb http://archive.raspbian.org/raspbian/ {{os_codename}} main contrib non-free rpi"
-{% else %}
+{%- else %}
         OTHERMIRROR="deb [trusted=yes] file:${LOCAL_REPO} ./ | deb http://ftp.us.debian.org/debian/ {{os_codename}} main | deb http://ftp.us.debian.org/debian/ {{os_codename}} contrib | deb http://ftp.us.debian.org/debian/ {{os_codename}}-updates main | deb http://ftp.us.debian.org/debian/ {{os_codename}}-backports main "
-{% endif %}
+{%- endif %}
 
 
 build_prefs:

--- a/file_roots/setup/debian/map.jinja
+++ b/file_roots/setup/debian/map.jinja
@@ -3,7 +3,8 @@
 
 # Get the user under which to build
 {# {% set build_runas = pillar.get('build_runas', basecfg.build_runas) %} #}
-{% set build_runas = 'root' %}
+## {# {% set build_runas = 'root' %} #}
+{% set build_runas = 'admin' %}
 
 # Get the repo signing timeout
 {% set repo_sign_timeout = basecfg.repo_sign_timeout %}

--- a/file_roots/setup/debian/map.jinja
+++ b/file_roots/setup/debian/map.jinja
@@ -2,9 +2,9 @@
 {% import "setup/base_map.jinja" as basecfg %}
 
 # Get the user under which to build
-{# {% set build_runas = pillar.get('build_runas', basecfg.build_runas) %} #}
+{% set build_runas = pillar.get('build_runas', basecfg.build_runas) %}
 ## {# {% set build_runas = 'root' %} #}
-{% set build_runas = 'admin' %}
+## {# {% set build_runas = 'admin' %} #}
 
 # Get the repo signing timeout
 {% set repo_sign_timeout = basecfg.repo_sign_timeout %}

--- a/file_roots/setup/ubuntu/gpg_agent.sls
+++ b/file_roots/setup/ubuntu/gpg_agent.sls
@@ -20,7 +20,7 @@
 {% set write_env_file_prefix = '' %}
 {% set write_env_file = '' %}
 {% set pinentry_parms = '
-        pinentry-timeout 20
+        pinentry-timeout 30
         allow-loopback-pinentry' %}
 {% set pinentry_text = 'pinentry-program /usr/bin/pinentry-tty' %}
 {% endif %}
@@ -28,14 +28,14 @@
 {% set pkg_pub_key_absfile = gpg_key_dir ~ '/' ~ pkg_pub_key_file %}
 {% set pkg_priv_key_absfile = gpg_key_dir ~ '/' ~ pkg_priv_key_file %}
 
-{% set gpg_agent_log_file = '/root/gpg-agent.log' %}
+{% set gpg_agent_log_file = build_cfg.build_homedir ~ '/gpg-agent.log' %}
 
 {% set gpg_agent_text = '# enable-ssh-support
         ' ~ write_env_file  ~ '
-        default-cache-ttl 300
-        default-cache-ttl-ssh 300
-        max-cache-ttl 300
-        max-cache-ttl-ssh 300
+        default-cache-ttl 600
+        default-cache-ttl-ssh 600
+        max-cache-ttl 600
+        max-cache-ttl-ssh 600
         allow-preset-passphrase
         daemon
         debug-all
@@ -46,6 +46,13 @@
         ' ~ pinentry_text ~ pinentry_parms
 %}
 
+{% set gpg_agent_script_file = build_cfg.build_homedir ~ '/gpg-agent_start.sh' %}
+
+{% set gpg_agent_script_text = 'gpg-agent --homedir ' ~ gpg_key_dir ~ ' ' ~ write_env_file_prefix ~ write_env_file ~ ' --allow-preset-passphrase --max-cache-ttl 600 --daemon
+        GPG_TTY=$(tty);
+        export GPG_TTY
+        echo "GPG_TTY=${GPG_TTY}" > ' ~ gpg_tty_info ~ '
+' %}
 
 
 gpg_agent_stop:
@@ -63,6 +70,11 @@ gpg_dir_rm:
 gpg_clear_agent_log:
   file.absent:
     - name: {{gpg_agent_log_file}}
+
+
+gpg_agent_script_file_rm:
+  file.absent:
+    - name: {{gpg_agent_script_file}}
 
 
 manage_priv_key:
@@ -90,51 +102,63 @@ manage_pub_key:
 
 
 gpg_conf_file_exists:
-  file.touch:
+  file.managed:
     - name: {{gpg_config_file}}
+    - dir_mode: 700
+    - mode: 644
+    - show_changes: False
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
     - makedirs: True
+    - contents: 'use-agent'
 
 
 gpg_tty_file_exists:
-  file.touch:
+  file.managed:
     - name: {{gpg_tty_info}}
+    - dir_mode: 700
+    - mode: 644
+    - show_changes: False
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
     - makedirs: True
-
-
-gpg_conf_file:
-  file.replace:
-    - name: {{gpg_config_file}}
-    - pattern: |
-        ^#\s*use-agent\s*\.*
-    - repl: |
-        use-agent
-    - count: 1
-    - append_if_not_found: True
-    - require:
-      - file: gpg_conf_file_exists
+    - contents: ''
 
 
 gpg_agent_conf_file:
-  file.append:
+  file.managed:
     - name: {{gpg_agent_config_file}}
+    - dir_mode: 700
+    - mode: 644
+    - show_changes: False
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
     - makedirs: True
-    - text: |
+    - contents: |
         {{gpg_agent_text}}
+
+
+gpg_agent_script_file_exists:
+  file.managed:
+    - name: {{gpg_agent_script_file}}
+    - dir_mode: 755
+    - mode: 755
+    - show_changes: False
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - makedirs: True
+    - contents: |
+        {{gpg_agent_script_text}}
 
 
 gpg_agent_start:
   cmd.run:
-    - name: |
-        eval $(gpg-agent --homedir {{gpg_key_dir}} {{write_env_file_prefix}}{{write_env_file}} --allow-preset-passphrase --max-cache-ttl 300 --daemon)
-        GPG_TTY=$(tty)
-        export GPG_TTY
-        echo "GPG_TTY=${GPG_TTY}" > {{gpg_tty_info}}
-#    - python_shell: True
-    - use_vt: True
-    - runas: {{build_cfg.build_runas}}
-    - reload_modules: True
-    - require:
-      - cmd: gpg_agent_stop
+   - name:  {{gpg_agent_script_file}}
+   - runas: {{build_cfg.build_runas}}
+   - use_vt: True
+   - reload_modules: True
+   - require:
+     - cmd: gpg_agent_stop
 
 
 gpg_load_pub_key:

--- a/file_roots/setup/ubuntu/map.jinja
+++ b/file_roots/setup/ubuntu/map.jinja
@@ -2,8 +2,8 @@
 {% import "setup/base_map.jinja" as basecfg %}
 
 # Get the user under which to build
-{# {% set build_runas = pillar.get('build_runas', basecfg.build_runas) %} #}
-{% set build_runas = 'root' %}
+{% set build_runas = pillar.get('build_runas', basecfg.build_runas) %}
+## {# {% set build_runas = 'root' %} #}
 ## {# {% set build_runas = 'ubuntu' %} #}
 
 # Get the repo signing timeout

--- a/file_roots/setup/ubuntu/map.jinja
+++ b/file_roots/setup/ubuntu/map.jinja
@@ -4,6 +4,7 @@
 # Get the user under which to build
 {# {% set build_runas = pillar.get('build_runas', basecfg.build_runas) %} #}
 {% set build_runas = 'root' %}
+## {# {% set build_runas = 'ubuntu' %} #}
 
 # Get the repo signing timeout
 {% set repo_sign_timeout = basecfg.repo_sign_timeout %}

--- a/file_roots/setup/ubuntu/ubuntu1404/init.sls
+++ b/file_roots/setup/ubuntu/ubuntu1404/init.sls
@@ -5,24 +5,31 @@
 {% set prefs_text = 'Package: *
         Pin: origin ""
         Pin-Priority: 1001
+
         Package: *
-        Pin: release a=' ~ os_codename ~ '-backports
+        Pin: release n=' ~ os_codename ~ '-backports
         Pin-Priority: 750
+
         Package: *
-        Pin: release a=' ~ os_codename ~ '-security
+        Pin: release n=' ~ os_codename ~ '-security
         Pin-Priority: 740
+
         Package: *
-        Pin: release a=' ~ os_codename ~ '-updates
+        Pin: release n=' ~ os_codename ~ '-updates
         Pin-Priority: 730
+
         Package: *
         Pin: release a=main
         Pin-Priority: 700
+
         Package: *
         Pin: release a=restricted
         Pin-Priority: 650
+
         Package: *
         Pin: release a=universe
         Pin-Priority: 600
+
         Package: *
         Pin: release a=multiverse
         Pin-Priority: 550
@@ -64,7 +71,7 @@ build_pbldhooks_rm_G05:
 
 build_pbldhooks_rm_D04:
   file.absent:
-    - name: {{build_cfg.build_homedir}}t/.pbuilder-hooks/D04update_local_repo
+    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/D04update_local_repo
 
 
 build_pbldrc_rm:
@@ -75,32 +82,6 @@ build_pbldrc_rm:
 build_prefs_rm:
   file.absent:
     - name: /etc/apt/preferences
-
-
-build_pbldhooks_file_G05:
-  file.append:
-    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/G05apt-preferences
-    - makedirs: True
-    - text: |
-        #!/bin/sh
-        set -e
-        cat > "/etc/apt/preferences" << EOF
-        {{prefs_text}}
-        EOF
-
-
-build_pbldhooks_file_D04:
-  file.append:
-    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/D04update_local_repo
-    - makedirs: True
-    - text: |
-        #!/bin/sh
-        # path to local repo
-        LOCAL_REPO="{{build_cfg.build_dest_dir}}"
-        # Generate a Packages file
-        ( cd ${LOCAL_REPO} ; /usr/bin/apt-ftparchive packages . > "${LOCAL_REPO}/Packages" )
-        # Update to include any new packagers in the local repo
-        apt-get --allow-unauthenticated update
 
 
 build_pbldhooks_perms:
@@ -116,10 +97,49 @@ build_pbldhooks_perms:
         - mode
 
 
+build_pbldhooks_file_G05:
+  file.managed:
+    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/G05apt-preferences
+    - makedirs: True
+    - dir_mode: 0755
+    - mode: 0775
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - contents: |
+        #!/bin/sh
+        set -e
+        cat > "/etc/apt/preferences" << @EOF
+        {{prefs_text}}
+        @EOF
+
+
+build_pbldhooks_file_D04:
+  file.managed:
+    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/D04update_local_repo
+    - makedirs: True
+    - dir_mode: 0755
+    - mode: 0775
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - contents: |
+        #!/bin/sh
+        # path to local repo
+        LOCAL_REPO="{{build_cfg.build_dest_dir}}"
+        # Generate a Packages file
+        ( cd ${LOCAL_REPO} ; /usr/bin/apt-ftparchive packages . > "${LOCAL_REPO}/Packages" )
+        # Update to include any new packagers in the local repo
+        apt-get --allow-unauthenticated update
+
+
 build_pbldrc:
-  file.append:
+  file.managed:
     - name: {{build_cfg.build_homedir}}/.pbuilderrc
-    - text: |
+    - makedirs: True
+    - dir_mode: 0755
+    - mode: 0775
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - contents: |
         DIST="{{os_codename}}"
         LOCAL_REPO="{{build_cfg.build_dest_dir}}"
 

--- a/file_roots/setup/ubuntu/ubuntu1604/init.sls
+++ b/file_roots/setup/ubuntu/ubuntu1604/init.sls
@@ -45,6 +45,7 @@ build_additional_pkgs:
     - pkgs:
       - dh-systemd
       - pinentry-tty
+      - python-sphinx
 
 
 {% if build_cfg.build_py3 %}
@@ -63,6 +64,7 @@ build_additional_py3_pkgs:
       - python3-gnupg
       - apt-utils
 {% endif %}
+
 
 build_pbldhooks_rm_G05:
   file.absent:
@@ -84,32 +86,6 @@ build_prefs_rm:
     - name: /etc/apt/preferences
 
 
-build_pbldhooks_file_G05:
-  file.append:
-    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/G05apt-preferences
-    - makedirs: True
-    - text: |
-        #!/bin/sh
-        set -e
-        cat > "/etc/apt/preferences" << EOF
-        {{prefs_text}}
-        EOF
-
-
-build_pbldhooks_file_D04:
-  file.append:
-    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/D04update_local_repo
-    - makedirs: True
-    - text: |
-        #!/bin/sh
-        # path to local repo
-        LOCAL_REPO="{{build_cfg.build_dest_dir}}"
-        # Generate a Packages file
-        ( cd ${LOCAL_REPO} ; /usr/bin/apt-ftparchive packages . > "${LOCAL_REPO}/Packages" )
-        # Update to include any new packagers in the local repo
-        apt-get --allow-unauthenticated update
-
-
 build_pbldhooks_perms:
   file.directory:
     - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/
@@ -123,10 +99,49 @@ build_pbldhooks_perms:
         - mode
 
 
+build_pbldhooks_file_G05:
+  file.managed:
+    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/G05apt-preferences
+    - makedirs: True
+    - dir_mode: 0755
+    - mode: 0775
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - contents: |
+        #!/bin/sh
+        set -e
+        cat > "/etc/apt/preferences" << @EOF
+        {{prefs_text}}
+        @EOF
+
+
+build_pbldhooks_file_D04:
+  file.managed:
+    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/D04update_local_repo
+    - makedirs: True
+    - dir_mode: 0755
+    - mode: 0775
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - contents: |
+        #!/bin/sh
+        # path to local repo
+        LOCAL_REPO="{{build_cfg.build_dest_dir}}"
+        # Generate a Packages file
+        ( cd ${LOCAL_REPO} ; /usr/bin/apt-ftparchive packages . > "${LOCAL_REPO}/Packages" )
+        # Update to include any new packagers in the local repo
+        apt-get --allow-unauthenticated update
+
+
 build_pbldrc:
-  file.append:
+  file.managed:
     - name: {{build_cfg.build_homedir}}/.pbuilderrc
-    - text: |
+    - makedirs: True
+    - dir_mode: 0755
+    - mode: 0775
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - contents: |
         DIST="{{os_codename}}"
         LOCAL_REPO="{{build_cfg.build_dest_dir}}"
 

--- a/file_roots/setup/ubuntu/ubuntu1804/init.sls
+++ b/file_roots/setup/ubuntu/ubuntu1804/init.sls
@@ -41,11 +41,13 @@ include:
   - setup.ubuntu
   - setup.ubuntu.gpg_agent
 
+
 build_additional_pkgs:
   pkg.installed:
     - pkgs:
       - dh-systemd
       - pinentry-tty
+      - python-sphinx
 
 
 {% if build_cfg.build_py3 %}
@@ -64,6 +66,7 @@ build_additional_py3_pkgs:
       - python3-gnupg
       - apt-utils
 {% endif %}
+
 
 build_pbldhooks_rm_G05:
   file.absent:
@@ -85,32 +88,6 @@ build_prefs_rm:
     - name: /etc/apt/preferences
 
 
-build_pbldhooks_file_G05:
-  file.append:
-    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/G05apt-preferences
-    - makedirs: True
-    - text: |
-        #!/bin/sh
-        set -e
-        cat > "/etc/apt/preferences" << EOF
-        {{prefs_text}}
-        EOF
-
-
-build_pbldhooks_file_D04:
-  file.append:
-    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/D04update_local_repo
-    - makedirs: True
-    - text: |
-        #!/bin/sh
-        # path to local repo
-        LOCAL_REPO="{{build_cfg.build_dest_dir}}"
-        # Generate a Packages file
-        ( cd ${LOCAL_REPO} ; /usr/bin/apt-ftparchive packages . > "${LOCAL_REPO}/Packages" )
-        # Update to include any new packagers in the local repo
-        apt-get --allow-unauthenticated update
-
-
 build_pbldhooks_perms:
   file.directory:
     - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/
@@ -124,10 +101,49 @@ build_pbldhooks_perms:
         - mode
 
 
+build_pbldhooks_file_G05:
+  file.managed:
+    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/G05apt-preferences
+    - makedirs: True
+    - dir_mode: 0755
+    - mode: 0775
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - contents: |
+        #!/bin/sh
+        set -e
+        cat > "/etc/apt/preferences" << @EOF
+        {{prefs_text}}
+        @EOF
+
+
+build_pbldhooks_file_D04:
+  file.managed:
+    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/D04update_local_repo
+    - makedirs: True
+    - dir_mode: 0755
+    - mode: 0775
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - contents: |
+        #!/bin/sh
+        # path to local repo
+        LOCAL_REPO="{{build_cfg.build_dest_dir}}"
+        # Generate a Packages file
+        ( cd ${LOCAL_REPO} ; /usr/bin/apt-ftparchive packages . > "${LOCAL_REPO}/Packages" )
+        # Update to include any new packagers in the local repo
+        apt-get --allow-unauthenticated update
+
+
 build_pbldrc:
-  file.append:
+  file.managed:
     - name: {{build_cfg.build_homedir}}/.pbuilderrc
-    - text: |
+    - makedirs: True
+    - dir_mode: 0755
+    - mode: 0775
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - contents: |
         DIST="{{os_codename}}"
         LOCAL_REPO="{{build_cfg.build_dest_dir}}"
 


### PR DESCRIPTION
Needed to allow for non-root user for Debian 9 (and 8 and Ubuntu 18.04 by association) on Amazon AWS.

These changes also require up coming Fluorine based Salt debbuild.py