### PR TITLE
Further support Py 3 Only Amazon Linux 2, Redhat 7,8 due to nightly builds

### DIFF
--- a/file_roots/pkg/python-chardet/3_0_4/amzn2/spec/python-chardet.spec
+++ b/file_roots/pkg/python-chardet/3_0_4/amzn2/spec/python-chardet.spec
@@ -11,7 +11,7 @@
 %global pypi_name chardet
 Name:           python-%{pypi_name}
 Version:        3.0.4
-Release:        10%{?dist}
+Release:        11%{?dist}
 Summary:        Character encoding auto-detection in Python
 License:        LGPLv2
 URL:            https://github.com/%{pypi_name}/%{pypi_name}
@@ -111,11 +111,14 @@ CFLAGS="%{optflags}" %{__python3} setup.py %{?py_setup_args} install -O1 --skip-
 %doc README.rst
 %{python3_sitelib}/%{pypi_name}/
 %{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info/
-%{_bindir}/chardetect
+%exclude %{_bindir}/chardetect
 %endif
 
 
 %changelog
+* Fri Jun 29 2019 SaltStack Packaging Team <packaging@saltstack.com> - 3.0.4-11
+- Exclude chardetect for now,as python-chardet is installed by default and conflicts
+
 * Wed Jun 19 2019 SaltStack Packaging Team <packaging@saltstack.com> - 3.0.4-10
 - Added support for Amazon Linux 2 Python 3
 

--- a/file_roots/pkg/python-psutil/5_4_3/amzn2/spec/python-psutil.spec
+++ b/file_roots/pkg/python-psutil/5_4_3/amzn2/spec/python-psutil.spec
@@ -110,12 +110,11 @@ sleep 1
 %install
 %if %{with python2}
 %py2_install
-%if %{with python3}
 %endif
+%if %{with python3}
 ## %%py3_install
 ## amzn2 has issue with %{py_setup} expansion
 CFLAGS="%{optflags}" %{__python3} setup.py %{?py_setup_args} install -O1 --skip-build --root %{buildroot} %{?*}
-
 %endif
 
 %if %{with tests}
@@ -126,6 +125,7 @@ make test-memleaks PYTHON=%%{__python2}
 %endif
 %if %{with python3}
 make test-memleaks PYTHON=%%{__python3}
+%endif
 %endif
 
 
@@ -148,7 +148,7 @@ make test-memleaks PYTHON=%%{__python3}
 
 
 %changelog
-* Mon Jun 17 2019 SaltStack Packaging Team <packaging@saltstack.com> - 5.4.3-8
+* Thu Jun 20 2019 SaltStack Packaging Team <packaging@saltstack.com> - 5.4.3-8
 - Made support for Python 2 optional
 
 * Thu Oct 04 2018 SaltStack Packaging Team <packaging@saltstack.com> - 5.4.3-7

--- a/file_roots/pkg/salt/2018_3/amzn2/init.sls
+++ b/file_roots/pkg/salt/2018_3/amzn2/init.sls
@@ -47,9 +47,9 @@
       - salt://{{slspath}}/sources/{{pkg_name}}-syndic.service
       - salt://{{slspath}}/sources/{{pkg_name}}.bash
       - salt://{{slspath}}/sources/{{pkg_name}}-proxy@.service
-      - salt://{{slspath}}/sources/{{pkg_name}}-py3-{{version}}-tornado4.patch
-      - salt://{{slspath}}/sources/{{pkg_name}}-py3-{{version}}-gpg-strbytes.patch
-      - salt://{{slspath}}/sources/{{pkg_name}}-py3-{{version}}-rpmsign.patch
+      - salt://{{slspath}}/sources/{{pkg_name}}-py3-2018.3.0-tornado4.patch
+      - salt://{{slspath}}/sources/{{pkg_name}}-py3-2018.3.0-gpg-strbytes.patch
+      - salt://{{slspath}}/sources/{{pkg_name}}-py3-2018.3.0-rpmsign.patch
       - salt://{{slspath}}/sources/fish-completions/{{pkg_name}}.fish
       - salt://{{slspath}}/sources/fish-completions/{{pkg_name}}_common.fish
       - salt://{{slspath}}/sources/fish-completions/{{pkg_name}}-call.fish

--- a/file_roots/pkg/salt/2018_3/amzn2/spec/salt.spec
+++ b/file_roots/pkg/salt/2018_3/amzn2/spec/salt.spec
@@ -48,9 +48,9 @@ Source19: salt-minion.fish
 Source20: salt-run.fish
 Source21: salt-syndic.fish
 
-Patch0:  salt-py3-%{version}-rpmsign.patch
-Patch1:  salt-py3-%{version}-tornado4.patch
-Patch2:  salt-py3-%{version}-gpg-strbytes.patch
+Patch0:  salt-py3-2018.3.0-rpmsign.patch
+Patch1:  salt-py3-2018.3.0-tornado4.patch
+Patch2:  salt-py3-2018.3.0-gpg-strbytes.patch
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch: noarch
@@ -795,7 +795,7 @@ rm -rf %{buildroot}
 
 
 %changelog
-* Mon Jun 28 2019 SaltStack Packaging Team <packaging@saltstack.com> - 2018.3.0-2
+* Fri Jun 28 2019 SaltStack Packaging Team <packaging@saltstack.com> - 2018.3.0-2
 - Made support for Python 2 on Amazon Linux 2 optional
 - Support for Python 3 only on Amazon Linux 2
 

--- a/file_roots/pkg/salt/2018_3/rhel7/init.sls
+++ b/file_roots/pkg/salt/2018_3/rhel7/init.sls
@@ -47,8 +47,8 @@
       - salt://{{slspath}}/sources/{{pkg_name}}-syndic.service
       - salt://{{slspath}}/sources/{{pkg_name}}.bash
       - salt://{{slspath}}/sources/{{pkg_name}}-proxy@.service
-      - salt://{{slspath}}/sources/{{pkg_name}}-py3-{{version}}-gpg-strbytes.patch
-      - salt://{{slspath}}/sources/{{pkg_name}}-py3-{{version}}-rpmsign.patch
+      - salt://{{slspath}}/sources/{{pkg_name}}-py3-2018.3.0-gpg-strbytes.patch
+      - salt://{{slspath}}/sources/{{pkg_name}}-py3-2018.3.0-rpmsign.patch
       - salt://{{slspath}}/sources/fish-completions/{{pkg_name}}.fish
       - salt://{{slspath}}/sources/fish-completions/{{pkg_name}}_common.fish
       - salt://{{slspath}}/sources/fish-completions/{{pkg_name}}-call.fish

--- a/file_roots/pkg/salt/2018_3/rhel7/spec/salt.spec
+++ b/file_roots/pkg/salt/2018_3/rhel7/spec/salt.spec
@@ -49,10 +49,10 @@ Source20: salt-run.fish
 Source21: salt-syndic.fish
 
 %if 0%{?rhel} > 7
-Patch0:  salt-py3-%{version}-tornado4.patch
+Patch0:  salt-py3-2018.3.0-tornado4.patch
 %endif
-Patch1:  salt-py3-%{version}-gpg-strbytes.patch
-Patch2:  salt-py3-%{version}-rpmsign.patch
+Patch1:  salt-py3-2018.3.0-gpg-strbytes.patch
+Patch2:  salt-py3-2018.3.0-rpmsign.patch
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch: noarch
@@ -506,7 +506,7 @@ rm -rf %{buildroot}
 
 
 %changelog
-* Thu Jun 06 2019 SaltStack Packaging Team <packaging@saltstack.com> - 2018.3.0-3
+* Fri Jun 28 2019 SaltStack Packaging Team <packaging@saltstack.com> - 2018.3.0-3
 - Support for Redhat 7 need for PyYAML and tornado 4 patch since Tornado < v5.x
 
 * Thu May 23 2019 SaltStack Packaging Team <packaging@saltstack.com> - 2019.2.0-7

--- a/file_roots/pkg/salt/2019_2/amzn2/init.sls
+++ b/file_roots/pkg/salt/2019_2/amzn2/init.sls
@@ -47,9 +47,9 @@
       - salt://{{slspath}}/sources/{{pkg_name}}-syndic.service
       - salt://{{slspath}}/sources/{{pkg_name}}.bash
       - salt://{{slspath}}/sources/{{pkg_name}}-proxy@.service
-      - salt://{{slspath}}/sources/{{pkg_name}}-py3-{{version}}-tornado4.patch
-      - salt://{{slspath}}/sources/{{pkg_name}}-py3-{{version}}-gpg-strbytes.patch
-      - salt://{{slspath}}/sources/{{pkg_name}}-py3-{{version}}-rpmsign.patch
+      - salt://{{slspath}}/sources/{{pkg_name}}-py3-2019.2.0-tornado4.patch
+      - salt://{{slspath}}/sources/{{pkg_name}}-py3-2019.2.0-gpg-strbytes.patch
+      - salt://{{slspath}}/sources/{{pkg_name}}-py3-2019.2.0-rpmsign.patch
       - salt://{{slspath}}/sources/fish-completions/{{pkg_name}}.fish
       - salt://{{slspath}}/sources/fish-completions/{{pkg_name}}_common.fish
       - salt://{{slspath}}/sources/fish-completions/{{pkg_name}}-call.fish

--- a/file_roots/pkg/salt/2019_2/amzn2/spec/salt.spec
+++ b/file_roots/pkg/salt/2019_2/amzn2/spec/salt.spec
@@ -13,10 +13,11 @@
 
 
 # Release Candidate
-%define __rc_ver tobereplaced_date
-## %%define __rc_ver %{nil}
+## %define __rc_ver nb201906271929454099573
+%%define __rc_ver %{nil}
 
 %define fish_dir %{_datadir}/fish/vendor_functions.d
+
 
 Name:    salt
 Version: 2019.2.0%{?__rc_ver}
@@ -48,9 +49,9 @@ Source19: salt-minion.fish
 Source20: salt-run.fish
 Source21: salt-syndic.fish
 
-## Patch0:  salt-py3-%%{version}-rpmsign.patch
-Patch1:  salt-py3-%{version}-tornado4.patch
-Patch2:  salt-py3-%{version}-gpg-strbytes.patch
+Patch0:  salt-py3-2019.2.0-rpmsign.patch
+Patch1:  salt-py3-2019.2.0-tornado4.patch
+Patch2:  salt-py3-2019.2.0-gpg-strbytes.patch
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch: noarch
@@ -326,9 +327,7 @@ Supports Python 2.
 ## %%autosetup
 %setup -q -c
 cd %{name}-%{version}
-## %%if 0%%{?rhel} > 7
-## %%patch0 -p1
-## %%endif
+%patch0 -p1
 %patch1 -p1
 %patch2 -p1
 
@@ -795,7 +794,7 @@ rm -rf %{buildroot}
 
 
 %changelog
-* Fri Jun 21 2019 SaltStack Packaging Team <packaging@saltstack.com> - 2019.2.0-2
+* Fri Jun 28 2019 SaltStack Packaging Team <packaging@saltstack.com> - 2019.2.0-2
 - Made support for Python 2 on Amazon Linux 2 optional
 
 * Mon Mar 11 2019 SaltStack Packaging Team <packaging@saltstack.com> - 2019.2.0-1

--- a/file_roots/pkg/salt/2019_2/rhel7/init.sls
+++ b/file_roots/pkg/salt/2019_2/rhel7/init.sls
@@ -47,8 +47,8 @@
       - salt://{{slspath}}/sources/{{pkg_name}}-syndic.service
       - salt://{{slspath}}/sources/{{pkg_name}}.bash
       - salt://{{slspath}}/sources/{{pkg_name}}-proxy@.service
-      - salt://{{slspath}}/sources/{{pkg_name}}-py3-{{version}}-gpg-strbytes.patch
-      - salt://{{slspath}}/sources/{{pkg_name}}-py3-{{version}}-rpmsign.patch
+      - salt://{{slspath}}/sources/{{pkg_name}}-py3-2019.2.0-gpg-strbytes.patch
+      - salt://{{slspath}}/sources/{{pkg_name}}-py3-2019.2.0-rpmsign.patch
       - salt://{{slspath}}/sources/fish-completions/{{pkg_name}}.fish
       - salt://{{slspath}}/sources/fish-completions/{{pkg_name}}_common.fish
       - salt://{{slspath}}/sources/fish-completions/{{pkg_name}}-call.fish

--- a/file_roots/pkg/salt/2019_2/rhel7/spec/salt.spec
+++ b/file_roots/pkg/salt/2019_2/rhel7/spec/salt.spec
@@ -48,10 +48,10 @@ Source20: salt-run.fish
 Source21: salt-syndic.fish
 
 %if 0%{?rhel} > 7
-Patch0:  salt-py3-%{version}-tornado4.patch
+Patch0:  salt-py3-2019.2.0-tornado4.patch
 %endif
-Patch1:  salt-py3-%{version}-gpg-strbytes.patch
-Patch2:  salt-py3-%{version}-rpmsign.patch
+Patch1:  salt-py3-2019.2.0-gpg-strbytes.patch
+Patch2:  salt-py3-2019.2.0-rpmsign.patch
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch: noarch
@@ -505,7 +505,7 @@ rm -rf %{buildroot}
 
 
 %changelog
-* Thu Jun 06 2019 SaltStack Packaging Team <packaging@saltstack.com> - 2019.2.0-8
+* Fri Jun 28 2019 SaltStack Packaging Team <packaging@saltstack.com> - 2019.2.0-8
 - Support for Redhat 7 need for PyYAML and tornado 4 patch since Tornado < v5.x
 
 * Thu May 23 2019 SaltStack Packaging Team <packaging@saltstack.com> - 2019.2.0-7

--- a/file_roots/pkg/salt/2019_2/rhel8/init.sls
+++ b/file_roots/pkg/salt/2019_2/rhel8/init.sls
@@ -47,9 +47,9 @@
       - salt://{{slspath}}/sources/{{pkg_name}}-syndic.service
       - salt://{{slspath}}/sources/{{pkg_name}}.bash
       - salt://{{slspath}}/sources/{{pkg_name}}-proxy@.service
-      - salt://{{slspath}}/sources/{{pkg_name}}-py3-{{version}}-tornado4.patch
-      - salt://{{slspath}}/sources/{{pkg_name}}-py3-{{version}}-gpg-strbytes.patch
-      - salt://{{slspath}}/sources/{{pkg_name}}-py3-{{version}}-rpmsign.patch
+      - salt://{{slspath}}/sources/{{pkg_name}}-py3-2019.2.0-tornado4.patch
+      - salt://{{slspath}}/sources/{{pkg_name}}-py3-2019.2.0-gpg-strbytes.patch
+      - salt://{{slspath}}/sources/{{pkg_name}}-py3-2019.2.0-rpmsign.patch
       - salt://{{slspath}}/sources/fish-completions/{{pkg_name}}.fish
       - salt://{{slspath}}/sources/fish-completions/{{pkg_name}}_common.fish
       - salt://{{slspath}}/sources/fish-completions/{{pkg_name}}-call.fish

--- a/file_roots/pkg/salt/2019_2/rhel8/spec/salt.spec
+++ b/file_roots/pkg/salt/2019_2/rhel8/spec/salt.spec
@@ -48,10 +48,10 @@ Source20: salt-run.fish
 Source21: salt-syndic.fish
 
 %if 0%{?rhel} > 7
-Patch0:  salt-py3-%{version}-tornado4.patch
+Patch0:  salt-py3-2019.2.0-tornado4.patch
 %endif
-Patch1:  salt-py3-%{version}-gpg-strbytes.patch
-Patch2:  salt-py3-%{version}-rpmsign.patch
+Patch1:  salt-py3-2019.2.0-gpg-strbytes.patch
+Patch2:  salt-py3-2019.2.0-rpmsign.patch
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch: noarch
@@ -505,7 +505,7 @@ rm -rf %{buildroot}
 
 
 %changelog
-* Thu Jun 06 2019 SaltStack Packaging Team <packaging@saltstack.com> - 2019.2.0-8
+* Fri Jun 28 2019 SaltStack Packaging Team <packaging@saltstack.com> - 2019.2.0-8
 - Support for Redhat 7 need for PyYAML and tornado 4 patch since Tornado < v5.x
 
 * Thu May 23 2019 SaltStack Packaging Team <packaging@saltstack.com> - 2019.2.0-7

--- a/file_roots/setup/amazon/init.sls
+++ b/file_roots/setup/amazon/init.sls
@@ -4,6 +4,7 @@
 
 build_pkgs:
   pkg.installed:
+    - allow_updates: True
     - pkgs:
       - createrepo
       - mock
@@ -12,6 +13,7 @@ build_pkgs:
       - gnupg2
       - python3-gnupg
       - wget
+      - rpm: latest
 
 
 {{build_cfg.build_runas}}:

--- a/pillar_roots/versions/2019_2/pkgbuild.sls
+++ b/pillar_roots/versions/2019_2/pkgbuild.sls
@@ -505,7 +505,7 @@ pkgbuild_registry:
       results:
         - python3-bottle
     python-chardet:
-      version: 3.0.4-10
+      version: 3.0.4-11
       noarch: True
       results:
         - python3-chardet


### PR DESCRIPTION
Note patching still to evaluated since gpg str /bytes just merged into 2018.3 and 2019.2.1