### PR TITLE
copy pillar to 3001rc1 folder, rhel7 python-distro is named python36-distro

### DIFF
--- a/pillar_roots/versions/3001rc1/pkgbuild.sls
+++ b/pillar_roots/versions/3001rc1/pkgbuild.sls
@@ -323,6 +323,11 @@ pkgbuild_registry:
         - python-mock
       results:
         - python36-cherrypy
+    python-distro:
+      version: 1.2.0-4
+      noarch: True
+      results:
+        - python36-distro
     python-crypto:
       version: 2.6.1-26
       build_deps:

--- a/pillar_roots/versions/master/pkgbuild.sls
+++ b/pillar_roots/versions/master/pkgbuild.sls
@@ -327,7 +327,7 @@ pkgbuild_registry:
       version: 1.2.0-4
       noarch: True
       results:
-        - python3-distro
+        - python36-distro
     python-crypto:
       version: 2.6.1-26
       build_deps:


### PR DESCRIPTION
copy pillar to 3001rc1 folder, rhel7 python-distro is named python36-distro