### PR TITLE
RPM SPECs: set /etc/logrotate.d/salt as %config(noreplace)

### DIFF
--- a/file_roots/pkg/salt/master/amzn2/spec/salt.spec
+++ b/file_roots/pkg/salt/master/amzn2/spec/salt.spec
@@ -607,7 +607,7 @@ rm -rf %{buildroot}
 %{python2_sitelib}/%{name}/*
 #%%{python2_sitelib}/%%{name}-%%{version}-py?.?.egg-info
 %{python2_sitelib}/%{name}-*-py?.?.egg-info
-%{_sysconfdir}/logrotate.d/salt
+%config(noreplace) %{_sysconfdir}/logrotate.d/salt
 %{_sysconfdir}/bash_completion.d/salt.bash
 %{_var}/cache/salt
 %{_var}/log/salt

--- a/file_roots/pkg/salt/master/fedora/spec/salt.spec
+++ b/file_roots/pkg/salt/master/fedora/spec/salt.spec
@@ -309,7 +309,7 @@ rm -rf %{buildroot}
 %defattr(-,root,root,-)
 %{python3_sitelib}/%{name}/*
 %{python3_sitelib}/%{name}-*-py?.?.egg-info
-%{_sysconfdir}/logrotate.d/salt
+%config(noreplace) %{_sysconfdir}/logrotate.d/salt
 %{_sysconfdir}/bash_completion.d/salt.bash
 %{_var}/cache/salt
 %{_var}/log/salt
@@ -606,7 +606,7 @@ rm -rf %{buildroot}
 - Revised versions of cherrypy acceptable
 
 * Tue Jul 24 2018 SaltStack Packaging Team <packaging@saltstack.com> - 2018.3.2-5
-- Fix version of python used, multiple addition of 2.7 
+- Fix version of python used, multiple addition of 2.7
 
 * Sat Jul 14 2018 Fedora Release Engineering <releng@fedoraproject.org> - 2018.3.2-4
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_29_Mass_Rebuild

--- a/file_roots/pkg/salt/master/rhel7/spec/salt.spec
+++ b/file_roots/pkg/salt/master/rhel7/spec/salt.spec
@@ -310,7 +310,7 @@ rm -rf %{buildroot}
 %defattr(-,root,root,-)
 %{python3_sitelib}/%{name}/*
 %{python3_sitelib}/%{name}-*-py?.?.egg-info
-%{_sysconfdir}/logrotate.d/salt
+%config(noreplace) %{_sysconfdir}/logrotate.d/salt
 %{_sysconfdir}/bash_completion.d/salt.bash
 %{_var}/cache/salt
 %{_var}/log/salt

--- a/file_roots/pkg/salt/master/rhel8/spec/salt.spec
+++ b/file_roots/pkg/salt/master/rhel8/spec/salt.spec
@@ -320,7 +320,7 @@ rm -rf %{buildroot}
 %defattr(-,root,root,-)
 %{python3_sitelib}/%{name}/*
 %{python3_sitelib}/%{name}-*-py?.?.egg-info
-%{_sysconfdir}/logrotate.d/salt
+%config(noreplace) %{_sysconfdir}/logrotate.d/salt
 %{_sysconfdir}/bash_completion.d/salt.bash
 %{_var}/cache/salt
 %{_var}/log/salt


### PR DESCRIPTION
This prevents the logrotate configuration from being stomped on by a
Salt upgrade.