### PR TITLE
Updated Amazon 2 Linux spec for logrotate noreplace

### DIFF
--- a/file_roots/pkg/salt/master/amzn2/spec/salt.spec
+++ b/file_roots/pkg/salt/master/amzn2/spec/salt.spec
@@ -517,7 +517,7 @@ rm -rf %{buildroot}
 %defattr(-,root,root,-)
 %{python3_sitelib}/%{name}/*
 %{python3_sitelib}/%{name}-*-py?.?.egg-info
-%{_sysconfdir}/logrotate.d/salt
+%config(noreplace) %{_sysconfdir}/logrotate.d/salt
 %{_sysconfdir}/bash_completion.d/salt.bash
 %{_var}/cache/salt
 %{_var}/log/salt


### PR DESCRIPTION
Updated logrotate for Amazon Linux 2 to match RHEL 7 & 8